### PR TITLE
Add simple auth page with login and register forms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Auth from "./pages/Auth";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/auth" element={<Auth />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,16 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { 
-  Search, 
-  Plus, 
-  MessageCircle, 
-  Bell, 
+import {
+  Search,
+  Plus,
+  MessageCircle,
+  Bell,
   User,
   Menu,
   Heart
 } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const Header = () => {
   return (
@@ -63,8 +64,11 @@ const Header = () => {
               <Heart className="h-5 w-5" />
             </Button>
             
-            <Button variant="ghost" size="sm">
-              <User className="h-5 w-5" />
+            <Button variant="ghost" size="sm" asChild>
+              <Link to="/auth" className="flex items-center gap-2">
+                <User className="h-5 w-5" />
+                <span className="hidden sm:inline">Ingresar</span>
+              </Link>
             </Button>
             
             <Button variant="ghost" size="sm" className="md:hidden">

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,0 +1,177 @@
+import { FormEvent, useState } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { toast } from "@/components/ui/use-toast";
+
+const Auth = () => {
+  const [loginForm, setLoginForm] = useState({ email: "", password: "" });
+  const [registerForm, setRegisterForm] = useState({
+    name: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
+  });
+
+  const handleLoginSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!loginForm.email || !loginForm.password) {
+      toast({
+        title: "Datos incompletos",
+        description: "Ingresa tu correo y contraseña para continuar.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    toast({
+      title: "Sesión iniciada",
+      description: "Bienvenido de nuevo a TruequePlus.",
+    });
+  };
+
+  const handleRegisterSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!registerForm.name || !registerForm.email || !registerForm.password || !registerForm.confirmPassword) {
+      toast({
+        title: "Datos incompletos",
+        description: "Todos los campos son obligatorios para crear tu cuenta.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (registerForm.password !== registerForm.confirmPassword) {
+      toast({
+        title: "Las contraseñas no coinciden",
+        description: "Revisa que ambas contraseñas sean iguales.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    toast({
+      title: "Registro exitoso",
+      description: "Tu cuenta fue creada y puedes iniciar sesión cuando quieras.",
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-muted flex items-center justify-center p-4">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>Bienvenido a TruequePlus</CardTitle>
+          <CardDescription>
+            Crea una cuenta nueva o inicia sesión para comenzar a intercambiar productos y servicios.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Tabs defaultValue="login" className="space-y-4">
+            <TabsList className="grid grid-cols-2">
+              <TabsTrigger value="login">Iniciar sesión</TabsTrigger>
+              <TabsTrigger value="register">Registrarme</TabsTrigger>
+            </TabsList>
+            <TabsContent value="login">
+              <form className="space-y-4" onSubmit={handleLoginSubmit}>
+                <div className="space-y-2">
+                  <Label htmlFor="login-email">Correo electrónico</Label>
+                  <Input
+                    id="login-email"
+                    type="email"
+                    placeholder="tu@correo.com"
+                    value={loginForm.email}
+                    onChange={(event) => setLoginForm({ ...loginForm, email: event.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="login-password">Contraseña</Label>
+                  <Input
+                    id="login-password"
+                    type="password"
+                    placeholder="••••••••"
+                    value={loginForm.password}
+                    onChange={(event) => setLoginForm({ ...loginForm, password: event.target.value })}
+                    required
+                  />
+                </div>
+                <Button type="submit" className="w-full">
+                  Iniciar sesión
+                </Button>
+              </form>
+            </TabsContent>
+            <TabsContent value="register">
+              <form className="space-y-4" onSubmit={handleRegisterSubmit}>
+                <div className="space-y-2">
+                  <Label htmlFor="register-name">Nombre completo</Label>
+                  <Input
+                    id="register-name"
+                    placeholder="Tu nombre"
+                    value={registerForm.name}
+                    onChange={(event) => setRegisterForm({ ...registerForm, name: event.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="register-email">Correo electrónico</Label>
+                  <Input
+                    id="register-email"
+                    type="email"
+                    placeholder="tu@correo.com"
+                    value={registerForm.email}
+                    onChange={(event) => setRegisterForm({ ...registerForm, email: event.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="register-password">Contraseña</Label>
+                  <Input
+                    id="register-password"
+                    type="password"
+                    placeholder="Crea una contraseña"
+                    value={registerForm.password}
+                    onChange={(event) => setRegisterForm({ ...registerForm, password: event.target.value })}
+                    required
+                    minLength={6}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="register-confirm-password">Confirmar contraseña</Label>
+                  <Input
+                    id="register-confirm-password"
+                    type="password"
+                    placeholder="Repite tu contraseña"
+                    value={registerForm.confirmPassword}
+                    onChange={(event) =>
+                      setRegisterForm({ ...registerForm, confirmPassword: event.target.value })
+                    }
+                    required
+                    minLength={6}
+                  />
+                </div>
+                <Button type="submit" className="w-full">
+                  Crear cuenta
+                </Button>
+              </form>
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+        <CardFooter className="flex-col gap-2 text-sm text-muted-foreground">
+          <span>
+            Al continuar aceptas nuestros términos y condiciones. Puedes volver al inicio cuando quieras.
+          </span>
+          <Button variant="link" asChild>
+            <Link to="/">Volver a la página principal</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+};
+
+export default Auth;


### PR DESCRIPTION
## Summary
- add an Auth page with tabbed login and registration forms using toast feedback
- register the Auth route in the router and link to it from the header navigation

## Testing
- npm run lint *(fails: existing lint errors in shadcn UI boilerplate)*

------
https://chatgpt.com/codex/tasks/task_e_68d09a6ba4e4832295a995bbcac1aacf