### PR TITLE
Connect header login button to auth page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Auth from "./pages/Auth";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +19,7 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/auth" element={<Auth />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNotifications, type Notification, type NotificationCategory } from "@/hooks/use-notifications";
 import { cn } from "@/lib/utils";
+import { Link } from "react-router-dom";
 import {
   AlertTriangle,
   ArrowLeftRight,
@@ -205,8 +206,10 @@ const Header = () => {
             </Button>
             
 
-            <Button variant="ghost" size="sm">
-              <User className="h-5 w-5" />
+            <Button variant="ghost" size="sm" asChild>
+              <Link to="/auth" aria-label="Iniciar sesión">
+                <User className="h-5 w-5" />
+              </Link>
             </Button>
             
 


### PR DESCRIPTION
## Summary
- connect the header login control to the `/auth` route using a router Link
- register the `/auth` page in the app router so navigation succeeds

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d1a16a4420832290f2293c8f5ad3c1