### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,54 +1,50 @@
-name: Deploy React app to GitHub Pages
+name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - main        # o la rama principal que uses (master, develop, etc.)
-  workflow_dispatch: {} # permite lanzar manualmente desde Actions UI
+    branches: [main]
+  workflow_dispatch:
 
-env:
-  NODE_VERSION: '18'        # ajusta si necesitas otra versión
-  PUBLISH_DIR: 'build'      # cambiar a 'dist' si usas Vite
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write       # necesario para que el action haga push a gh-pages
-      pages: write
-      id-token: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 20
+          cache: npm
 
       - name: Install dependencies
-        run: |
-          npm ci
+        run: npm ci
 
-      - name: Build app
-        run: |
-          npm run build
+      - name: Build project
+        run: npm run build
 
-      - name: Prepare 404 fallback for SPA (single page apps)
-        # copia index.html a 404.html para que GitHub Pages sirva la SPA en rutas deep-link
-        run: |
-          if [ -f "${{ env.PUBLISH_DIR }}/index.html" ]; then
-            cp "${{ env.PUBLISH_DIR }}/index.html" "${{ env.PUBLISH_DIR }}/404.html" || true
-          fi
-
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.PUBLISH_DIR }}
-          publish_branch: gh-pages
-          user_name: github-actions
-          user_email: actions@github.com
+          path: dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/211dc7bf-810c-4902-af07-4778c7a4955a) and click on Share -> Publish.
 
+### Deploying to GitHub Pages
+
+This repository is also configured to deploy automatically to GitHub Pages using GitHub Actions:
+
+1. Push your changes to the `main` branch.
+2. In your repository on GitHub, go to **Settings → Pages** and make sure the **Build and deployment** source is set to **GitHub Actions**.
+3. Each push to `main` will build the project with `npm run build` and publish the contents of the `dist` folder to GitHub Pages.
+
+If you need to deploy manually, you can trigger the **Deploy to GitHub Pages** workflow from the **Actions** tab with the **Run workflow** button.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === "production" ? "/tq-exchange-hub/" : "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure the Vite base path so production builds work on GitHub Pages
- add a GitHub Actions workflow that builds the site and deploys it to Pages
- document how to trigger the new deployment in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4936dd480832283d71780c2876968